### PR TITLE
[src/parser.rs] Loosen parse validation so that just the executable path suffices

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -149,8 +149,14 @@ fn parse_command(command_line: &Vec<&str>, spec: &CliSpec) -> (bool, usize) {
                             && OsStr::new(&command_strings[0]) == root_command_file_name
                         {
                             let mut found = true;
-                            for index in 1..command_strings.len() {
+                            for index in 0..command_strings.len() {
                                 if command_strings[index] != command_line[index] {
+                                    {
+                                        let base = OsStr::new(&command_strings[index]);
+                                        if base == root_command_file_name {
+                                            return (true, index + base.len());
+                                        }
+                                    }
                                     found = false;
                                     break;
                                 }


### PR DESCRIPTION
EDIT: Curiously `./target/debug/makers --version` and `./target/debug/makers --help` now works but `./target/debug/cargo-make --version` and `./target/debug/cargo-make --help` work as if neither `--help` nor `--version` were provided